### PR TITLE
fix: Incorrect commands w/ creating template

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ The following commands will perform the following:
 * (Optional): Set CPU Type to `host`. This is necessary if you plan on running any sort of nested virtualization on said Virtual Machine (e.g., Docker, Hyper-V, etc.)
 ```bash
 qm set $VM_ID --ide0 file=none && \
-qm set $VM_ID --ide2 $STORAGE_POOL:Cloudinit && \
+qm set $VM_ID --ide2 $STORAGE_POOL:cloudinit && \
 qm set $VM_ID --boot "order=ide0;virtio0;net0" --bootdisk virtio0 && \
 qm set $VM_ID --ostype l26 && \
 qm set $VM_ID --serial0 socket --vga serial0

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ apt-get -y install libguestfs-tools
   
 ```bash
 virt-customize -a jammy-server-cloudimg-amd64.img --install qemu-guest-agent
+
+virt-customize -a jammy-server-cloudimg-amd64.img --run-command "systemctl enable qemu-guest-agent"
 ```
 * (OPTIONAL): If you're **NOT** using an SSL Certificate within Cloudinit drive on said Virtual Machine, you'll need to modify SSH in said image to allow local authentication, which can be done running said command
   

--- a/README.md
+++ b/README.md
@@ -218,14 +218,19 @@ qm set $VM_ID --agent enabled=1,fstrim_cloned_disks=1
 ```
 
 The following commands will perform the following:
+* Create a variable to determine the location of our imported disk. This is necessary as some storage pools create the destination directory differently. A variable fixes said inconsistencies.
 * Add a CD-ROM to `ide0` (in case you need to reinstall the Virtual Machine at a later date)
+* Import the unused disk image as a `virtio0` disk. This requires scsihw `virtio-scsi-pci`
 * Add a Cloudinit drive to `ide2`
 * Set the boot order to `CD-ROM (ide0) -> Disk (virtio0) -> Network Adapter (net0)` and set the bootdisk to disk `virtio0`
 * Set the OS Type to `Linux: 6.x - 2.6 Kernel` 
 * Add a serial adapter `serial0` and update our display to `serial0`
 * (Optional): Set CPU Type to `host`. This is necessary if you plan on running any sort of nested virtualization on said Virtual Machine (e.g., Docker, Hyper-V, etc.)
 ```bash
+export DISK_LOC="$STORAGE_POOL:$(qm config $VM_ID | grep -Po "(?<=unused\d: $STORAGE_POOL:).*")"
+
 qm set $VM_ID --ide0 file=none && \
+qm set $VM_ID --scsihw virtio-scsi-pci --virtio0 $DISK_LOC && \
 qm set $VM_ID --ide2 $STORAGE_POOL:cloudinit && \
 qm set $VM_ID --boot "order=ide0;virtio0;net0" --bootdisk virtio0 && \
 qm set $VM_ID --ostype l26 && \


### PR DESCRIPTION
## Description
The documentation under **Getting Started** was incorrect. I observed the following issues:
* QEMU-Guest-Agent was NOT starting upon boot. This was resolved by adding the following line in the documentation:
```bash
virt-customize -a jammy-server-cloudimg-amd64.img --run-command "systemctl enable qemu-guest-agent"
```
* Creating a Cloud-init drive was not working due to the `C` being capitalized in the following line:
```bash
qm set $VM_ID --ide2 "$STORAGE_POOL:Cloudinit" && \
```
* The fix for this issue is to have a lower-case `C` for Cloudinit, like so:
```bash
qm set $VM_ID --ide2 "$STORAGE_POOL:cloudinit" && \
```

* The documentation was missing a step with creating a `virtio` drive from the imported disk image. The following lines were added in the documentation to fix this issue:
```bash
export DISK_LOC="$STORAGE_POOL:$(qm config $VM_ID | grep -Po "(?<=unused\d: $STORAGE_POOL:).*")"
qm set $VM_ID --scsihw virtio-scsi-pci --virtio0 $DISK_LOC && \
```

## Motivation and Context
It's paramount to have a supported image to use this module and the documentation under **Getting Started** highlights ***how*** to meet the requirements to utilize said module. 

## Breaking Changes
N/A

## How Has This Been Tested?
I've followed the updated documentation on all of my Proxmox nodes. I can confirm that QEMU-Guest-Agent was running after deploying said Virtual Machine(s). 