### PR TITLE
fix: incorrect ssh_user value

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -28,7 +28,7 @@ output "ssh_settings" {
   value = var.create_vm ? {
     ssh_host = try(proxmox_vm_qemu.cloudinit[0].ssh_host, "")
     ssh_port = try(proxmox_vm_qemu.cloudinit[0].ssh_port, "")
-    ssh_user = try(proxmox_vm_qemu.cloudinit[0].ssh_user, "")
+    ssh_user = try(proxmox_vm_qemu.cloudinit[0].ssh_user != null ? proxmox_vm_qemu.cloudinit[0].ssh_user : proxmox_vm_qemu.cloudinit[0].ciuser, "")
     sshkeys  = try(proxmox_vm_qemu.cloudinit[0].sshkeys, "")
   } : null
 


### PR DESCRIPTION
## Description
Output `ssh_settings` was using variable `ssh_user` which is not defined in this module. The fix is to check if `ssh_user` exists, if it does not, replace it with `ciuser`. 